### PR TITLE
build: Update setup script to include self signed cert generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Courtbot is a simple web service for subscribing to case hearing details via SMS
 - Run Setup: `mix setup`
 - Start Phoenix: `mix phx.server`
 
-After `mix phx.server` Phoenix will running and for next steps in setting up Courtbot see [here](https://github.com/boisebrigade/Courtbot/wiki/Configuration) for additional details.
+After `mix phx.server` Phoenix will start running and for next steps in setting up Courtbot see [here](https://github.com/boisebrigade/Courtbot/wiki/Configuration) for additional details.
 
 ## Documentation
 - [Overview](https://github.com/boisebrigade/Courtbot/wiki)

--- a/mix.exs
+++ b/mix.exs
@@ -74,7 +74,7 @@ defmodule Courtbot.Mixfile do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "ecto.setup"],
+      setup: ["deps.get", "ecto.setup", "phx.gen.cert selfsigned"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]


### PR DESCRIPTION
## What

Adds self signed cert generation to the setup script.

## Why

Attempting to start the server without priv/cert/selfsigned.pem and selfsigned_key.pem will throw the following error upon running `mix phx.server`.

```bash
mix phx.server
19:02:45.767 [info] Application courtbot exited: Courtbot.Application.start(:normal, []) returned an error: shutdown: failed to start child: CourtbotWeb.Endpoint
    ** (EXIT) an exception was raised:
        ** (ArgumentError) could not start Cowboy2 adapter, the file /Users/blakedietz/projects/personal/courtbot/_build/dev/lib/courtbot/priv/cert/selfsigned_key.pem required by SSL's :keyfile either does not exist, or the application does not have permission to access it
            (plug_cowboy) lib/plug/cowboy.ex:296: Plug.Cowboy.fail/1
            (plug_cowboy) lib/plug/cowboy.ex:60: Plug.Cowboy.args/4
            (plug_cowboy) lib/plug/cowboy.ex:163: Plug.Cowboy.child_spec/1
            (phoenix) lib/phoenix/endpoint/cowboy2_adapter.ex:44: Phoenix.Endpoint.Cowboy2Adapter.child_spec/3
            (phoenix) lib/phoenix/endpoint/supervisor.ex:108: anonymous fn/6 in Phoenix.Endpoint.Supervisor.server_children/4
            (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
            (phoenix) lib/phoenix/endpoint/supervisor.ex:99: Phoenix.Endpoint.Supervisor.server_children/4
            (phoenix) lib/phoenix/endpoint/supervisor.ex:59: Phoenix.Endpoint.Supervisor.init/1
            (stdlib) supervisor.erl:295: :supervisor.init/1
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
** (Mix) Could not start application courtbot: Courtbot.Application.start(:normal, []) returned an error: shutdown: failed to start child: CourtbotWeb.Endpoint
    ** (EXIT) an exception was raised:
        ** (ArgumentError) could not start Cowboy2 adapter, the file /Users/blakedietz/projects/personal/courtbot/_build/dev/lib/courtbot/priv/cert/selfsigned_key.pem required by SSL's :keyfile either does not exist, or the application does not have permission to access it
            (plug_cowboy) lib/plug/cowboy.ex:296: Plug.Cowboy.fail/1
            (plug_cowboy) lib/plug/cowboy.ex:60: Plug.Cowboy.args/4
            (plug_cowboy) lib/plug/cowboy.ex:163: Plug.Cowboy.child_spec/1
            (phoenix) lib/phoenix/endpoint/cowboy2_adapter.ex:44: Phoenix.Endpoint.Cowboy2Adapter.child_spec/3
            (phoenix) lib/phoenix/endpoint/supervisor.ex:108: anonymous fn/6 in Phoenix.Endpoint.Supervisor.server_children/4
            (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
            (phoenix) lib/phoenix/endpoint/supervisor.ex:99: Phoenix.Endpoint.Supervisor.server_children/4
            (phoenix) lib/phoenix/endpoint/supervisor.ex:59: Phoenix.Endpoint.Supervisor.init/1
            (stdlib) supervisor.erl:295: :supervisor.init/1
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3

```
 